### PR TITLE
Show HTTP status levels (1xx, 2xx, etc.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Some configuration is supported through the default configuration file:
 
     metrics.jvm - [true/false] (default is true)
 
+    metrics.showHttpStatusLevels - [true/false] (default is false)
+
 ### Metrics Filter
 
 An implementation of the Metrics' instrumenting filter for Play2. It records requests duration, number of active requests and counts each return code

--- a/src/main/scala/com/kenshoo/play/metrics/MertricsPlugin.scala
+++ b/src/main/scala/com/kenshoo/play/metrics/MertricsPlugin.scala
@@ -43,6 +43,7 @@ class MetricsPlugin(val app: Application) extends Plugin {
   def rateUnit     = app.configuration.getString("metrics.rateUnit", validUnits).getOrElse("SECONDS")
   def durationUnit = app.configuration.getString("metrics.durationUnit", validUnits).getOrElse("SECONDS")
   def showSamples  = app.configuration.getBoolean("metrics.showSamples").getOrElse(false)
+  def showLevels   = app.configuration.getBoolean("metrics.showHttpStatusLevels").getOrElse(false)
 
   implicit def stringToTimeUnit(s: String) : TimeUnit = TimeUnit.valueOf(s)
 
@@ -57,6 +58,7 @@ class MetricsPlugin(val app: Application) extends Plugin {
       }
       val module = new MetricsModule(rateUnit, durationUnit, showSamples)
       mapper.registerModule(module)
+      MetricsFilter.showLevels = showLevels
     }
   }
 


### PR DESCRIPTION
Adds status level filtering.  That is, how many 1xx, 2xx, 3xx, 4xx, and 5.xx have been returned.
