### PR TITLE
meter by status level (1xx, 2xx, etc.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,11 @@ Some configuration is supported through the default configuration file:
     metrics.showSamples [true/false] (default is false)
 
     metrics.jvm - [true/false] (default is true)
-
+    
+    metrics.showHttpStatusLevels - [true/false] (default is false)
+    
+    metrics.knownStatuses - [list of Ints] (default is [200, 400, 403, 404, 201, 307, 500])
+    
 ### Metrics Filter
 
 An implementation of the Metrics' instrumenting filter for Play2. It records requests duration, number of active requests and counts each return code

--- a/src/main/scala/com/kenshoo/play/metrics/MetricsFilter.scala
+++ b/src/main/scala/com/kenshoo/play/metrics/MetricsFilter.scala
@@ -18,10 +18,13 @@ package com.kenshoo.play.metrics
 import play.api.mvc._
 import play.api.http.Status
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import play.api.Play
+import play.api.Play.current
 
 import com.codahale.metrics._
 import com.codahale.metrics.MetricRegistry.name
 
+import scala.collection.JavaConverters._
 
 abstract class MetricsFilter extends EssentialFilter {
 
@@ -30,7 +33,24 @@ abstract class MetricsFilter extends EssentialFilter {
   val knownStatuses = Seq(Status.OK, Status.BAD_REQUEST, Status.FORBIDDEN, Status.NOT_FOUND,
     Status.CREATED, Status.TEMPORARY_REDIRECT, Status.INTERNAL_SERVER_ERROR)
 
-  def statusCodes: Map[Int, Meter] = knownStatuses.map (s => s -> registry.meter(name(classOf[MetricsFilter], s.toString))).toMap
+  lazy val requestedStatuses = {
+    val userPrefStatuses = Play.configuration.getIntList("metrics.knownStatuses")
+    userPrefStatuses match {
+      case Some(s) => s.asScala.toList.map(x => x: Int)
+      case None => knownStatuses
+    }
+  }
+
+  lazy val statusCodes = newMeters(requestedStatuses, requestedStatuses.map(x => x.toString))
+
+  lazy val statusLevelMeters: Map[Int, Meter] = {
+    val showStatusLevelsEnabled =
+      Play.configuration.getBoolean("metrics.showHttpStatusLevels").getOrElse(false)
+    if (showStatusLevelsEnabled) {
+      val buckets = 1 to 5
+      newMeters(buckets, buckets.map(x => statusLevelName(x)))
+    } else Map()
+  }
 
   def requestsTimer:  Timer   = registry.timer(name(classOf[MetricsFilter], "requestTimer"))
   def activeRequests: Counter = registry.counter(name(classOf[MetricsFilter], "activeRequests"))
@@ -40,16 +60,33 @@ abstract class MetricsFilter extends EssentialFilter {
     def apply(rh: RequestHeader) = {
       val context = requestsTimer.time()
 
-      def logCompleted(result: Result): Result = {
+      def logCompleted(result: SimpleResult): SimpleResult = {
         activeRequests.dec()
         context.stop()
         statusCodes.getOrElse(result.header.status, otherStatuses).mark()
+        statusLevelMeters.get(statusLevel(result.header.status)).map(_.mark)
         result
       }
 
       activeRequests.inc()
       next(rh).map(logCompleted)
     }
+  }
+
+  /** The name of the status level of an HTTP status code (e.g., "2xx", "5xx") */
+  private def statusLevelName(s: Int): String = {
+    s + "xx"
+  }
+
+  private def statusLevel(s: Int) = s / 100
+
+  private def newMeters(keys: Seq[Int], names: Seq[String]): Map[Int, Meter] = {
+    keys.zip(names.map(name => newMeter(name))).toMap
+  }
+
+  /** Creates a new meter with the specified name */
+  private def newMeter(meterName: String): Meter = {
+    registry.meter(name(classOf[MetricsFilter], meterName))
   }
 }
 


### PR DESCRIPTION
This optionally adds new meters, for each level of statuses (1xx, 2xx, etc.), which allows the user to quickly see how many successful, failure, etc. requests have happened. 

Also makes the statuses to filter ("knownStatuses") user-configurable.

 Usage is controlled by config flags, and in the flag's absence, the old behavior is retained.
