### PR TITLE
Make metrics configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Configuration can optionally be overridden through subclassing MetricsFilter in 
 
 ## Changes
 
+2.3.0_0.1.9 - Support configuration of which HTTP statuses have metrics, and allow service checks to be counted seperately
 2.3.0_0.1.8 - Support default registry in play java. Replace MetricsRegistry.default with MetricsRegistry.defaultRegistry (to support java where default is a reserved keyword)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -77,5 +77,21 @@ An implementation of the Metrics' instrumenting filter for Play2. It records req
     object Global extends WithFilters(MetricsFilter)
 ```
 
+#### Configuration
+
+Configuration can optionally be overridden through subclassing MetricsFilter in order to change the prefix label for created metrics, to specify which HTTP Status codes should have individual metrics, and to classify URIs as healthchecks, for those to be counted seperately.
+
+```scala
+    import com.kenshoo.play.metrics.{MetricsRegistry, MetricsFilter}
+    import play.api.mvc._
+
+    class Global(val reg: MetricRegistry) extends WithFilters(new MetricsFilter{
+      val registry: MetricRegistry = reg
+      override val healthChecks: Seq[String] = Seq("/ok")
+      override val knownStatuses: Seq[Int] = Seq(Status.OK, Status.BAD_REQUEST, Status.FORBIDDEN, Status.NOT_FOUND, Status.CREATED, Status.TEMPORARY_REDIRECT, Status.INTERNAL_SERVER_ERROR)
+      override val label: String = classOf[MetricsFilter].getName
+    })
+```
+
 ## License
 This code is released under the Apache Public License 2.0.

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization:= "com.kenshoo"
 
 name := "metrics-play"
 
-version := "2.3.0_0.1.8"
+version := "2.3.0_0.1.9"
 
 scalaVersion := "2.11.2"
 

--- a/src/main/scala/com/kenshoo/play/metrics/MetricsFilter.scala
+++ b/src/main/scala/com/kenshoo/play/metrics/MetricsFilter.scala
@@ -25,8 +25,31 @@ import com.codahale.metrics.MetricRegistry.name
 
 abstract class MetricsFilter extends EssentialFilter {
   def registry: MetricRegistry
+
+  /** Specify a meaningful prefix for metrics
+    *
+    * Defaults to classOf[MetricsFilter].getName for backward compatibility as
+    * this was the original set value.
+    *
+    */
   def label: String = classOf[MetricsFilter].getName
+
+  /** Specify URIs as monitoring checks
+    *
+    * Enables monitoring requests to be classified separately to regular traffic
+    * in order to ensure that metrics are not inadvertently skewed.
+    *
+    * Defaults to an empty sequence to maintain backward compatibility.
+    */
   def healthChecks: Seq[String] = Seq.empty
+
+  /** Specify which HTTP status codes have individual metrics
+    *
+    * Statuses not specified here are grouped together under otherStatuses
+    *
+    * Defaults to 200, 400, 403, 404, 201, 307, 500 to maintain compatibility
+    * with prior releases.
+    */
   def knownStatuses = Seq(Status.OK, Status.BAD_REQUEST, Status.FORBIDDEN, Status.NOT_FOUND,
     Status.CREATED, Status.TEMPORARY_REDIRECT, Status.INTERNAL_SERVER_ERROR)
 

--- a/src/main/scala/com/kenshoo/play/metrics/MetricsFilter.scala
+++ b/src/main/scala/com/kenshoo/play/metrics/MetricsFilter.scala
@@ -18,32 +18,40 @@ package com.kenshoo.play.metrics
 import play.api.mvc._
 import play.api.http.Status
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
-
 import com.codahale.metrics._
 import com.codahale.metrics.MetricRegistry.name
 
 
+
 abstract class MetricsFilter extends EssentialFilter {
-
   def registry: MetricRegistry
-
-  val knownStatuses = Seq(Status.OK, Status.BAD_REQUEST, Status.FORBIDDEN, Status.NOT_FOUND,
+  def label: String = classOf[MetricsFilter].getName
+  def healthChecks: Seq[String] = Seq.empty
+  def knownStatuses = Seq(Status.OK, Status.BAD_REQUEST, Status.FORBIDDEN, Status.NOT_FOUND,
     Status.CREATED, Status.TEMPORARY_REDIRECT, Status.INTERNAL_SERVER_ERROR)
 
-  def statusCodes: Map[Int, Meter] = knownStatuses.map (s => s -> registry.meter(name(classOf[MetricsFilter], s.toString))).toMap
+  def statusCodes: Map[Int, Meter] = knownStatuses.map(s => s -> registry.meter(name(label, s.toString))).toMap
+  def healthCheckStatusCodes: Map[Int, Meter] = knownStatuses.map( s => s -> registry.meter(name("HealthCheck_" + label, s.toString))).toMap
 
-  def requestsTimer:  Timer   = registry.timer(name(classOf[MetricsFilter], "requestTimer"))
-  def activeRequests: Counter = registry.counter(name(classOf[MetricsFilter], "activeRequests"))
-  def otherStatuses:  Meter   = registry.meter(name(classOf[MetricsFilter], "other"))
+  def requestsTimer: Timer = registry.timer(name(label, "requestTimer"))
+  def activeRequests: Counter = registry.counter(name(label, "activeRequests"))
+  def otherStatuses: Meter = registry.meter(name(label, "other"))
 
   def apply(next: EssentialAction) = new EssentialAction {
     def apply(rh: RequestHeader) = {
       val context = requestsTimer.time()
 
+      def isHealthCheck(uri: String): Boolean = healthChecks.find(_ == uri).nonEmpty
+
       def logCompleted(result: Result): Result = {
         activeRequests.dec()
         context.stop()
-        statusCodes.getOrElse(result.header.status, otherStatuses).mark()
+        if (isHealthCheck(rh.uri)) {
+          healthCheckStatusCodes.getOrElse(result.header.status, otherStatuses).mark()
+        }
+        else {
+          statusCodes.getOrElse(result.header.status, otherStatuses).mark()
+        }
         result
       }
 
@@ -52,6 +60,7 @@ abstract class MetricsFilter extends EssentialFilter {
     }
   }
 }
+
 
 object MetricsFilter extends MetricsFilter {
   def registry = MetricsRegistry.default


### PR DESCRIPTION
* Needed metrics for some additional http status codes. It seemed desirable to make this configurable. 
* Also made the prefix label for the metrics configurable, as this was useful in our case.
* Final change is allowing URIs to be marked as healthChecks, and exist as separate metrics, to avoid monitoring from skewing metrics.