### PR TITLE
rename default registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add metrics-play dependency:
 ```scala
     val appDependencies = Seq(
     ...
-    "com.kenshoo" %% "metrics-play" % "2.3.0_0.1.7"
+    "com.kenshoo" %% "metrics-play" % "2.3.0_0.1.8"
     )
 ```
 
@@ -38,7 +38,7 @@ where priority is the priority of this plugin with respect to other plugins.
      import com.kenshoo.play.metrics.MetricsRegistry
      import com.codahale.metrics.Counter
 
-     val counter = MetricsRegistry.default.counter("name")
+     val counter = MetricsRegistry.defaultRegistry.counter("name")
      counter.inc()
 ````
 
@@ -76,6 +76,26 @@ An implementation of the Metrics' instrumenting filter for Play2. It records req
 
     object Global extends WithFilters(MetricsFilter)
 ```
+
+ Note - to use the filter in play java, replace MetricsFilter class with JavaMetricsFilter
+
+ ```java
+    import com.kenshoo.play.metrics.JavaMetricsFilter;
+    import play.GlobalSettings;
+    import play.api.mvc.EssentialFilter;
+    
+    public class Global extends GlobalSettings {
+        @Override
+        public <T extends EssentialFilter> Class<T>[] filters() {
+    
+            return new Class[]{JavaMetricsFilter.class};
+        }
+    }
+ ```
+
+## Changes
+
+2.3.0_0.1.8 - Support default registry in play java. Replace MetricsRegistry.default with MetricsRegistry.defaultRegistry (to support java where default is a reserved keyword)
 
 ## License
 This code is released under the Apache Public License 2.0.

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization:= "com.kenshoo"
 
 name := "metrics-play"
 
-version := "2.3.0_0.1.7"
+version := "2.3.0_0.1.8"
 
 scalaVersion := "2.11.2"
 

--- a/src/main/scala/com/kenshoo/play/metrics/MetricsController.scala
+++ b/src/main/scala/com/kenshoo/play/metrics/MetricsController.scala
@@ -52,6 +52,6 @@ trait MetricsController {
 }
 
 object MetricsController extends Controller with MetricsController {
-  def registry = MetricsRegistry.default
+  def registry = MetricsRegistry.defaultRegistry
   def app = Play.current
 }

--- a/src/main/scala/com/kenshoo/play/metrics/MetricsFilter.scala
+++ b/src/main/scala/com/kenshoo/play/metrics/MetricsFilter.scala
@@ -23,7 +23,7 @@ import com.codahale.metrics._
 import com.codahale.metrics.MetricRegistry.name
 
 
-abstract class MetricsFilter extends EssentialFilter {
+trait MetricsFilter extends EssentialFilter {
 
   def registry: MetricRegistry
 
@@ -53,6 +53,13 @@ abstract class MetricsFilter extends EssentialFilter {
   }
 }
 
+/**
+ * use this filter when writing play java. bypasses the no ctor problem of scala object
+ */
+class JavaMetricsFilter extends MetricsFilter {
+  override def registry: MetricRegistry = MetricsRegistry.defaultRegistry
+}
+
 object MetricsFilter extends MetricsFilter {
-  def registry = MetricsRegistry.default
+  override def registry = MetricsRegistry.defaultRegistry
 }


### PR DESCRIPTION
fixes #5 and #22 
replace MetricsRegistry.default with MetricsREgistry.defaultRegistry (keep default for backward compatibility) 
