### PR TITLE
Configurable metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,20 @@ An implementation of the Metrics' instrumenting filter for Play2. It records req
         }
     }
  ```
+#### Configuration
+Configuration can optionally be overridden through subclassing MetricsFilter in order to change the prefix label for
+created metrics, and to specify which HTTP Status codes should have individual metrics.
+
+```scala
+    import com.kenshoo.play.metrics.{MetricsRegistry, MetricsFilter}
+    import play.api.mvc._
+
+    class Global(val reg: MetricRegistry) extends WithFilters(new MetricsFilter{
+      val registry: MetricRegistry = reg
+      override val knownStatuses: Seq[Int] = Seq(Status.OK, Status.BAD_REQUEST, Status.FORBIDDEN, Status.NOT_FOUND, Status.CREATED, Status.TEMPORARY_REDIRECT, Status.INTERNAL_SERVER_ERROR)
+      override val label: String = classOf[MetricsFilter].getName
+    })
+```
 
 ## Changes
 

--- a/src/main/scala/com/kenshoo/play/metrics/MetricsFilter.scala
+++ b/src/main/scala/com/kenshoo/play/metrics/MetricsFilter.scala
@@ -33,25 +33,25 @@ trait MetricsFilter extends EssentialFilter {
     * this was the original set value.
     *
     */
-  def label: String = classOf[MetricsFilter].getName
+  def labelPrefix: String = classOf[MetricsFilter].getName
 
   /** Specify which HTTP status codes have individual metrics
     *
     * Statuses not specified here are grouped together under otherStatuses
     *
-    * Defaults to 200, 400, 401, 403, 404, 409, 201, 307, 500 to maintain compatibility
+    * Defaults to 200, 400, 401, 403, 404, 409, 201, 304, 307, 500, which is compatible
     * with prior releases.
     */
   def knownStatuses = Seq(Status.OK, Status.BAD_REQUEST, Status.FORBIDDEN, Status.NOT_FOUND,
     Status.CREATED, Status.TEMPORARY_REDIRECT, Status.INTERNAL_SERVER_ERROR, Status.CONFLICT,
-    Status.UNAUTHORIZED)
+    Status.UNAUTHORIZED, Status.NOT_MODIFIED)
 
 
-  def statusCodes: Map[Int, Meter] = knownStatuses.map(s => s -> registry.meter(name(label, s.toString))).toMap
+  def statusCodes: Map[Int, Meter] = knownStatuses.map(s => s -> registry.meter(name(labelPrefix, s.toString))).toMap
 
-  def requestsTimer: Timer = registry.timer(name(label, "requestTimer"))
-  def activeRequests: Counter = registry.counter(name(label, "activeRequests"))
-  def otherStatuses: Meter = registry.meter(name(label, "other"))
+  def requestsTimer: Timer = registry.timer(name(labelPrefix, "requestTimer"))
+  def activeRequests: Counter = registry.counter(name(labelPrefix, "activeRequests"))
+  def otherStatuses: Meter = registry.meter(name(labelPrefix, "other"))
 
   def apply(next: EssentialAction) = new EssentialAction {
     def apply(rh: RequestHeader) = {

--- a/src/test/scala/com/kenshoo/play/metrics/MetricsFilterTest.scala
+++ b/src/test/scala/com/kenshoo/play/metrics/MetricsFilterTest.scala
@@ -16,6 +16,7 @@
 package com.kenshoo.play.metrics
 
 import org.specs2.mutable.Specification
+import play.api.http.Status
 import play.api.mvc._
 import play.api.test._
 import play.api.test.Helpers._
@@ -28,6 +29,8 @@ import scala.collection.JavaConversions._
 class MetricsFilterSpec extends Specification {
   sequential
 
+  val label = classOf[MetricsFilter].getName
+
   "metrics filter" should {
     "return passed response code" in new ApplicationWithFilter {
       val result = route(FakeRequest("GET", "/")).get
@@ -36,7 +39,7 @@ class MetricsFilterSpec extends Specification {
 
     "increment status code counter" in new ApplicationWithFilter {
       route(FakeRequest("GET", "/")).get
-      val meter: Meter = registry.meter(MetricRegistry.name(classOf[MetricsFilter], "200"))
+      val meter: Meter = registry.meter(MetricRegistry.name(label, "200"))
       val meters: Map[String, Meter] = registry.getMeters.toMap
       meters.foreach(m => println(m._1 +": " + m._2.getCount))
       meter.getCount must equalTo(1)
@@ -44,13 +47,17 @@ class MetricsFilterSpec extends Specification {
 
     "increment request timer" in new ApplicationWithFilter {
       route(FakeRequest("GET", "/")).get
-      val timer = registry.timer(MetricRegistry.name(classOf[MetricsFilter], "requestTimer"))
-      timer.getCount must beGreaterThan(0l)
+      val timer = registry.timer(MetricRegistry.name(label, "requestTimer"))
+      timer.getCount must beGreaterThan(0L)
     }
   }
 
   class MockGlobal(val reg: MetricRegistry) extends WithFilters(new MetricsFilter{
     val registry: MetricRegistry = reg
+    override val knownStatuses = Seq(Status.OK, Status.BAD_REQUEST, Status.FORBIDDEN, Status.NOT_FOUND,
+      Status.CREATED, Status.TEMPORARY_REDIRECT, Status.INTERNAL_SERVER_ERROR, Status.CONFLICT,
+      Status.UNAUTHORIZED)
+    override val label = classOf[MetricsFilter].getName
   }) {
     def handler = Action {
       Results.Ok("ok")

--- a/src/test/scala/com/kenshoo/play/metrics/MetricsFilterTest.scala
+++ b/src/test/scala/com/kenshoo/play/metrics/MetricsFilterTest.scala
@@ -29,7 +29,7 @@ import scala.collection.JavaConversions._
 class MetricsFilterSpec extends Specification {
   sequential
 
-  val label = classOf[MetricsFilter].getName
+  val labelPrefix = classOf[MetricsFilter].getName
 
   "metrics filter" should {
     "return passed response code" in new ApplicationWithFilter {
@@ -39,7 +39,7 @@ class MetricsFilterSpec extends Specification {
 
     "increment status code counter" in new ApplicationWithFilter {
       route(FakeRequest("GET", "/")).get
-      val meter: Meter = registry.meter(MetricRegistry.name(label, "200"))
+      val meter: Meter = registry.meter(MetricRegistry.name(labelPrefix, "200"))
       val meters: Map[String, Meter] = registry.getMeters.toMap
       meters.foreach(m => println(m._1 +": " + m._2.getCount))
       meter.getCount must equalTo(1)
@@ -47,7 +47,7 @@ class MetricsFilterSpec extends Specification {
 
     "increment request timer" in new ApplicationWithFilter {
       route(FakeRequest("GET", "/")).get
-      val timer = registry.timer(MetricRegistry.name(label, "requestTimer"))
+      val timer = registry.timer(MetricRegistry.name(labelPrefix, "requestTimer"))
       timer.getCount must beGreaterThan(0L)
     }
   }
@@ -57,7 +57,7 @@ class MetricsFilterSpec extends Specification {
     override val knownStatuses = Seq(Status.OK, Status.BAD_REQUEST, Status.FORBIDDEN, Status.NOT_FOUND,
       Status.CREATED, Status.TEMPORARY_REDIRECT, Status.INTERNAL_SERVER_ERROR, Status.CONFLICT,
       Status.UNAUTHORIZED)
-    override val label = classOf[MetricsFilter].getName
+    override val labelPrefix = classOf[MetricsFilter].getName
   }) {
     def handler = Action {
       Results.Ok("ok")


### PR DESCRIPTION
Following feed back in #23 , this is a simplification, which just:
* allows the configuration of which HTTP status codes have individual metrics, as otherwise, the range of defaults is becoming pretty huge, as it seems different use cases care about different response codes.

* allows the customization of the labelPrefix for metrics. This defaults to the previous value of `classOf[MetricsFilter].getName` but can now be set to different values. This could be used to make searching for metrics easier, or could be used to create different metrics for different service calls.