### PR TITLE
Deal with uncaught exceptions in MetricsFilter

### DIFF
--- a/src/test/scala/com/kenshoo/play/metrics/MetricsFilterTest.scala
+++ b/src/test/scala/com/kenshoo/play/metrics/MetricsFilterTest.scala
@@ -41,14 +41,12 @@ class MetricsFilterSpec extends Specification {
     "increment status code counter" in new ApplicationWithFilter {
       route(FakeRequest("GET", "/")).get
       val meter: Meter = registry.meter(MetricRegistry.name(labelPrefix, "200"))
-      val meters: Map[String, Meter] = registry.getMeters.toMap
       meter.getCount must equalTo(1)
     }
 
     "increment status code counter for uncaught exceptions" in new ApplicationWithFilter {
       Await.ready(route(FakeRequest("GET", "/throws")).get, Duration(2, "seconds"))
       val meter: Meter = registry.meter(MetricRegistry.name(labelPrefix, "500"))
-      val meters: Map[String, Meter] = registry.getMeters.toMap
       meter.getCount must equalTo(1)
     }
 


### PR DESCRIPTION
In the case of an uncaught exception during a request, logCompleted is never called. Common practice in Play apps is to have a global onError handler that returns an HTTP 500 result. Due to logCompleted never being called, these 500 results do not get caught by the MetricsFilter. Additionally, their timing is ignored, and activeRequests is never decremented.

This change addresses these issues by calling logCompleted with an InternalServerError result before propagating the exception. This also exchanges EssentialFilter for Filter, as EssentialFilter is lower-level and is not necessary for this class.