### PR TITLE
Set labelPrefix from configuration if available.

### DIFF
--- a/src/main/scala/com/kenshoo/play/metrics/Metrics.scala
+++ b/src/main/scala/com/kenshoo/play/metrics/Metrics.scala
@@ -21,10 +21,12 @@ trait Metrics {
   def defaultRegistry: MetricRegistry
 
   def toJson: String
+
+  def configuration: Configuration
 }
 
 @Singleton
-class MetricsImpl @Inject() (lifecycle: ApplicationLifecycle, configuration: Configuration) extends Metrics {
+class MetricsImpl @Inject() (lifecycle: ApplicationLifecycle, val configuration: Configuration) extends Metrics {
 
   val validUnits = Set("NANOSECONDS", "MICROSECONDS", "MILLISECONDS", "SECONDS", "MINUTES", "HOURS", "DAYS")
 
@@ -89,6 +91,8 @@ class DisabledMetrics @Inject() extends Metrics {
   def defaultRegistry: MetricRegistry = throw new MetricsDisabledException
 
   def toJson: String = throw new MetricsDisabledException
+
+  def configuration: Configuration = throw new MetricsDisabledException
 }
 
 class MetricsDisabledException extends Throwable

--- a/src/main/scala/com/kenshoo/play/metrics/MetricsFilter.scala
+++ b/src/main/scala/com/kenshoo/play/metrics/MetricsFilter.scala
@@ -43,7 +43,7 @@ class MetricsFilterImpl @Inject() (metrics: Metrics)(implicit val mat: Materiali
     * this was the original set value.
     *
     */
-  def labelPrefix: String = classOf[MetricsFilter].getName
+  def labelPrefix: String = metrics.configuration.getOptional[String]("metrics.labelPrefix").getOrElse(classOf[MetricsFilter].getName)
 
   /** Specify which HTTP status codes have individual metrics
     *

--- a/src/test/scala/com/kenshoo/play/metrics/MetricsControllerSpec.scala
+++ b/src/test/scala/com/kenshoo/play/metrics/MetricsControllerSpec.scala
@@ -16,6 +16,7 @@
 package com.kenshoo.play.metrics
 
 import org.specs2.mutable.Specification
+import play.api.Configuration
 import play.api.test.{FakeRequest, Helpers}
 import play.api.test.Helpers._
 
@@ -27,6 +28,7 @@ class MetricsControllerSpec extends Specification  {
       val controller = new MetricsController(new Metrics {
         def defaultRegistry = throw new NotImplementedError
         def toJson = "{}"
+        def configuration: Configuration = throw new NotImplementedError
       }, Helpers.stubControllerComponents())
 
       val result = controller.metrics.apply(FakeRequest())


### PR DESCRIPTION
Make configuration part of Metrics trait so that confiration is
available for MetricsFilter and other components.