### PR TITLE
Set labelPrefix from configuration if available.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,15 +59,38 @@ To enable the controller add a mapping to conf/routes file
 #### Configuration
 Some configuration is supported through the default configuration file:
 
-    metrics.rateUnit - (default is SECONDS) 
+    metrics.enabled - [true/false] (default is true)
+    
+    metrics.name - (default is "default") Name of the dropwizard metrics registry
+    
+    metrics.labelPrefix - (defaults to classname ("com.kenshoo.play.metrics.MetricsFilter"))
 
-    metrics.durationUnit (default is SECONDS)
+    metrics.rateUnit - (default is "SECONDS")
+
+    metrics.durationUnit (default is "SECONDS")
 
     metrics.showSamples [true/false] (default is false)
 
     metrics.jvm - [true/false] (default is true) controls reporting jvm metrics
   
     metrics.logback - [true/false] (default is true) controls reporing logback metrics
+
+
+#### Name prefix
+By default, metrics are prefixed with the name of the class: "com.kenshoo.play.metrics.MetricsFilter":
+
+```
+"com.kenshoo.play.metrics.MetricsFilter.200" : {
+   "count" : 1584456,
+   "m15_rate" : 1.6800220918042639,
+   "m1_rate" : 1.9015104460758263,
+   "m5_rate" : 1.8138545372237085,
+   "mean_rate" : 3.20162010446889,
+   "units" : "events/second"
+},
+```
+
+You can change the prefix with configuration key `metrics.labelPrefix` 
 
 ### Metrics Filter
 
@@ -85,20 +108,7 @@ An implementation of the Metrics' instrumenting filter for Play2. It records req
 
 ## Advanced usage
 
-By default, metrics are prefixed with "com.kenshoo.play.metrics.MetricsFilter".
-
-```
-"com.kenshoo.play.metrics.MetricsFilter.200" : {
-   "count" : 1584456,
-   "m15_rate" : 1.6800220918042639,
-   "m1_rate" : 1.9015104460758263,
-   "m5_rate" : 1.8138545372237085,
-   "mean_rate" : 3.20162010446889,
-   "units" : "events/second"
-},
-```
-
-You can change the prefix by extending `MetricsFilterImpl`.
+Inherit your own custom filter to implement modifications not available through configuration:
 
 ```scala
 package myapp
@@ -111,9 +121,6 @@ import play.api.inject.Module
 import play.api.{Configuration, Environment}
 
 class MyMetricsFilter @Inject() (metrics: Metrics) extends MetricsFilterImpl(metrics) {
-
-  // configure metrics prefix
-  override def labelPrefix: String = "foobar"
 
   // configure status codes to be monitored. other status codes are labeled as "other"
   override def knownStatuses = Seq(Status.OK)

--- a/src/main/scala/com/kenshoo/play/metrics/Metrics.scala
+++ b/src/main/scala/com/kenshoo/play/metrics/Metrics.scala
@@ -21,10 +21,12 @@ trait Metrics {
   def defaultRegistry: MetricRegistry
 
   def toJson: String
+
+  def configuration: Configuration
 }
 
 @Singleton
-class MetricsImpl @Inject() (lifecycle: ApplicationLifecycle, configuration: Configuration) extends Metrics {
+class MetricsImpl @Inject() (lifecycle: ApplicationLifecycle, val configuration: Configuration) extends Metrics {
 
   val validUnits = Set("NANOSECONDS", "MICROSECONDS", "MILLISECONDS", "SECONDS", "MINUTES", "HOURS", "DAYS")
 
@@ -89,6 +91,8 @@ class DisabledMetrics @Inject() extends Metrics {
   def defaultRegistry: MetricRegistry = throw new MetricsDisabledException
 
   def toJson: String = throw new MetricsDisabledException
+
+  def configuration: Configuration = throw new MetricsDisabledException
 }
 
 class MetricsDisabledException extends Throwable

--- a/src/main/scala/com/kenshoo/play/metrics/MetricsFilter.scala
+++ b/src/main/scala/com/kenshoo/play/metrics/MetricsFilter.scala
@@ -43,7 +43,7 @@ class MetricsFilterImpl @Inject() (metrics: Metrics)(implicit val mat: Materiali
     * this was the original set value.
     *
     */
-  def labelPrefix: String = classOf[MetricsFilter].getName
+  def labelPrefix: String = metrics.configuration.getOptional[String]("metrics.labelPrefix").getOrElse(classOf[MetricsFilter].getName)
 
   /** Specify which HTTP status codes have individual metrics
     *

--- a/src/test/scala/com/kenshoo/play/metrics/MetricsControllerSpec.scala
+++ b/src/test/scala/com/kenshoo/play/metrics/MetricsControllerSpec.scala
@@ -16,6 +16,7 @@
 package com.kenshoo.play.metrics
 
 import org.specs2.mutable.Specification
+import play.api.Configuration
 import play.api.test.{FakeRequest, Helpers}
 import play.api.test.Helpers._
 
@@ -27,6 +28,7 @@ class MetricsControllerSpec extends Specification  {
       val controller = new MetricsController(new Metrics {
         def defaultRegistry = throw new NotImplementedError
         def toJson = "{}"
+        def configuration: Configuration = throw new NotImplementedError
       }, Helpers.stubControllerComponents())
 
       val result = controller.metrics.apply(FakeRequest())


### PR DESCRIPTION
Make configuration part of Metrics trait so that configuration is
available for MetricsFilter and other components.

I did edit the README.md too to document the ability to configure the metrics prefix. Isn't it a bit problematic to have a documentation in master branch which would be ahead of the latest release though? If you had a development branch then master would equal to your latest release.