### PR TITLE
Upgrade Dropwizard Metrics to the latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To add a custom metrics, you can use `defaultRegistry` which returns an instance
 
 ```scala
      import com.kenshoo.play.metrics.Metrics
-     import com.codahale.metrics.Counter
+     import io.dropwizard.metrics5.Counter
 
      class SomeController @Inject() (metrics: Metrics) {
          val counter = metrics.defaultRegistry.counter("name")

--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,8 @@ val playVersion = "2.6.6"
 
 val metricsPlayVersion = "0.6.2"
 
+val dropWizardMetricsVersion = "5.0.0-rc1"
+
 version := s"${playVersion}_${metricsPlayVersion}"
 
 
@@ -27,10 +29,10 @@ resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"
 resolvers += "specs2" at "https://mvnrepository.com/artifact/org.specs2/specs2_2.12"
 
 libraryDependencies ++= Seq(
-    "io.dropwizard.metrics" % "metrics-core" % "3.2.4",
-    "io.dropwizard.metrics" % "metrics-json" % "3.2.4",
-    "io.dropwizard.metrics" % "metrics-jvm" % "3.2.4",
-    "io.dropwizard.metrics" % "metrics-logback" % "3.2.4",
+    "io.dropwizard.metrics5" % "metrics-core" % dropWizardMetricsVersion,
+    "io.dropwizard.metrics5" % "metrics-json" % dropWizardMetricsVersion,
+    "io.dropwizard.metrics5" % "metrics-jvm" %  dropWizardMetricsVersion,
+    "io.dropwizard.metrics5" % "metrics-logback" % dropWizardMetricsVersion,
     "com.typesafe.play" %% "play" % playVersion % "provided",
     "org.joda" % "joda-convert" % "1.8.2",
     //test

--- a/src/main/scala/com/kenshoo/play/metrics/Metrics.scala
+++ b/src/main/scala/com/kenshoo/play/metrics/Metrics.scala
@@ -5,16 +5,15 @@ import java.util.concurrent.TimeUnit
 import javax.inject.{Inject, Singleton}
 
 import ch.qos.logback.classic
-import com.codahale.metrics.json.MetricsModule
-import com.codahale.metrics.jvm.{ThreadStatesGaugeSet, MemoryUsageGaugeSet, GarbageCollectorMetricSet}
-import com.codahale.metrics.logback.InstrumentedAppender
-import com.codahale.metrics.{JvmAttributeGaugeSet, SharedMetricRegistries, MetricRegistry}
-import com.fasterxml.jackson.databind.{ObjectWriter, ObjectMapper}
-import play.api.{Logger, Configuration}
+import com.fasterxml.jackson.databind.{ObjectMapper, ObjectWriter}
+import io.dropwizard.metrics5.json.MetricsModule
+import io.dropwizard.metrics5.jvm.{GarbageCollectorMetricSet, JvmAttributeGaugeSet, MemoryUsageGaugeSet, ThreadStatesGaugeSet}
+import io.dropwizard.metrics5.logback.InstrumentedAppender
+import io.dropwizard.metrics5.{MetricName, MetricRegistry, SharedMetricRegistries}
 import play.api.inject.ApplicationLifecycle
+import play.api.{Configuration, Logger}
 
 import scala.concurrent.Future
-
 
 trait Metrics {
 
@@ -49,10 +48,10 @@ class MetricsImpl @Inject() (lifecycle: ApplicationLifecycle, configuration: Con
 
   def setupJvmMetrics(registry: MetricRegistry) {
     if (jvmMetricsEnabled) {
-      registry.register("jvm.attribute", new JvmAttributeGaugeSet())
-      registry.register("jvm.gc", new GarbageCollectorMetricSet())
-      registry.register("jvm.memory", new MemoryUsageGaugeSet())
-      registry.register("jvm.threads", new ThreadStatesGaugeSet())
+      registry.register(MetricName.build("jvm.attribute"), new JvmAttributeGaugeSet())
+      registry.register(MetricName.build("jvm.gc"), new GarbageCollectorMetricSet())
+      registry.register(MetricName.build("jvm.memory"), new MemoryUsageGaugeSet())
+      registry.register(MetricName.build("jvm.threads"), new ThreadStatesGaugeSet())
     }
   }
 

--- a/src/main/scala/com/kenshoo/play/metrics/MetricsFilter.scala
+++ b/src/main/scala/com/kenshoo/play/metrics/MetricsFilter.scala
@@ -20,8 +20,8 @@ import javax.inject.Inject
 import akka.stream.Materializer
 import play.api.mvc._
 import play.api.http.Status
-import com.codahale.metrics._
-import com.codahale.metrics.MetricRegistry.name
+import io.dropwizard.metrics5._
+import io.dropwizard.metrics5.MetricRegistry.name
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/src/test/scala/com/kenshoo/play/metrics/MetricsFilterSpec.scala
+++ b/src/test/scala/com/kenshoo/play/metrics/MetricsFilterSpec.scala
@@ -25,7 +25,7 @@ import play.api.mvc._
 import play.api.routing.Router
 import play.api.test._
 import play.api.test.Helpers._
-import com.codahale.metrics.MetricRegistry
+import io.dropwizard.metrics5.MetricRegistry
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.Await

--- a/src/test/scala/com/kenshoo/play/metrics/MetricsSpec.scala
+++ b/src/test/scala/com/kenshoo/play/metrics/MetricsSpec.scala
@@ -1,11 +1,13 @@
 package com.kenshoo.play.metrics
 
+import io.dropwizard.metrics5.MetricName
 import org.specs2.mutable.Specification
 import play.api.Application
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.libs.json.{Json, JsValue}
+import play.api.libs.json.{JsValue, Json}
 import play.api.test.Helpers._
+
 import scala.collection.JavaConverters._
 
 class MetricsSpec extends Specification {
@@ -27,7 +29,7 @@ class MetricsSpec extends Specification {
 
     "serialize to JSON" in withApplication(Map.empty) { implicit app =>
       val jsValue: JsValue = Json.parse(metrics.toJson)
-      (jsValue \ "version").as[String] mustEqual "3.1.3"
+      (jsValue \ "version").as[String] mustEqual "5.0.0"
     }
 
     "be able to add custom counter" in withApplication(Map("metrics.jvm" -> false)) { implicit app =>
@@ -38,19 +40,19 @@ class MetricsSpec extends Specification {
     }
 
     "contain JVM metrics" in withApplication(Map("metrics.jvm" -> true)) { implicit app =>
-      metrics.defaultRegistry.getGauges.asScala must haveKey("jvm.attribute.name")
+      metrics.defaultRegistry.getGauges.asScala must haveKey(MetricName.build("jvm.attribute.name"))
     }
 
     "contain logback metrics" in withApplication(Map.empty) { implicit app =>
-      metrics.defaultRegistry.getMeters.asScala must haveKey("ch.qos.logback.core.Appender.all")
+      metrics.defaultRegistry.getMeters.asScala must haveKey(MetricName.build("ch.qos.logback.core.Appender.all"))
     }
 
     "be able to turn off JVM metrics" in withApplication(Map("metrics.jvm" -> false)) { implicit app =>
-      metrics.defaultRegistry.getGauges.asScala must not haveKey("jvm.attribute.name")
+      metrics.defaultRegistry.getGauges.asScala must not haveKey MetricName.build("jvm.attribute.name")
     }
 
     "be able to turn off logback metrics" in withApplication(Map("metrics.logback" -> false)) { implicit app =>
-      metrics.defaultRegistry.getMeters.asScala must not haveKey("ch.qos.logback.core.Appender.all")
+      metrics.defaultRegistry.getMeters.asScala must not haveKey MetricName.build("ch.qos.logback.core.Appender.all")
     }
   }
 }


### PR DESCRIPTION
Metrics 5 is not yet released (RC1). This PR is currently here only for information, discussion and test purpose. I'd suggest to wait for the 5.0 to be released to merge this.